### PR TITLE
Merge with pcl_conversions officially released in Dashing

### DIFF
--- a/pcl_conversions/CMakeLists.txt
+++ b/pcl_conversions/CMakeLists.txt
@@ -12,49 +12,47 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-find_package(PCL REQUIRED COMPONENTS common io)
+find_package(PCL REQUIRED QUIET COMPONENTS common io)
 find_package(Eigen3 REQUIRED)
+find_package(message_filters REQUIRED)
 find_package(pcl_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
-# There is a bug in the Ubuntu Artful (17.10) version of the VTK package,
-# where it includes /usr/include/*-linux-gnu/freetype2 in the include
-# directories (which doesn't exist).  This filters down to the PCL_INCLUDE_DIRS,
-# and causes downstream projects trying to use these libraries to fail to
-# configure properly.  Here we remove those bogus entries so that downstream
-# consumers of this package succeed.
-if(NOT "${PCL_INCLUDE_DIRS}" STREQUAL "")
-  foreach(item ${PCL_INCLUDE_DIRS})
-    string(REGEX MATCH "/usr/include/.*-linux-gnu/freetype2" item ${item})
-    if(item)
-      list(REMOVE_ITEM PCL_INCLUDE_DIRS ${item})
-    endif()
-  endforeach()
-endif()
-
-
-include_directories(${rclcpp_INCLUDE_DIRS})
-
-ament_export_include_directories(include)
-
-ament_export_dependencies()
+include_directories(
+  include
+  ${message_filters_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
+  ${PCL_COMMON_INCLUDE_DIRS}
+  ${Eigen_INCLUDE_DIRS}
+)
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION include/${PROJECT_NAME}/
 )
 
-#if(BUILD_TESTING)
-#  find_package(catkin REQUIRED COMPONENTS roscpp pcl_msgs sensor_msgs std_msgs)
-#  include_directories(
-#    include
-#    ${catkin_INCLUDE_DIRS}
-#    ${PCL_INCLUDE_DIRS}
-#    ${EIGEN3_INCLUDE_DIRS})
-#
-#  catkin_add_gtest(test_pcl_conversions test/test_pcl_conversions.cpp)
-#  target_link_libraries(test_pcl_conversions ${catkin_LIBRARIES})
-#endif()
+# Add gtest based cpp test target
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(${PROJECT_NAME}-test test/test_pcl_conversions.cpp)
+  ament_target_dependencies(${PROJECT_NAME}-test
+    "rclcpp"
+    "sensor_msgs"
+    "std_msgs"
+    "pcl_msgs"
+  )
+  target_link_libraries(${PROJECT_NAME}-test ${Boost_LIBRARIES})
+endif()
+
+ament_export_include_directories(
+  include
+  ${rclcpp_INCLUDE_DIRS}
+  ${Eigen_INCLUDE_DIRS}
+  ${PCL_COMMON_INCLUDE_DIRS}
+)
+
+ament_export_dependencies()
 
 ament_package()

--- a/pcl_conversions/CMakeLists.txt
+++ b/pcl_conversions/CMakeLists.txt
@@ -12,9 +12,10 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-find_package(PCL REQUIRED QUIET COMPONENTS common io)
+find_package(Boost REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(message_filters REQUIRED)
+find_package(PCL REQUIRED QUIET COMPONENTS common io)
 find_package(pcl_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -22,10 +23,11 @@ find_package(std_msgs REQUIRED)
 
 include_directories(
   include
-  ${message_filters_INCLUDE_DIRS}
-  ${rclcpp_INCLUDE_DIRS}
-  ${PCL_COMMON_INCLUDE_DIRS}
   ${Eigen_INCLUDE_DIRS}
+  ${message_filters_INCLUDE_DIRS}
+  ${PCL_COMMON_INCLUDE_DIRS}
+  ${pcl_msgs_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
 )
 
 install(DIRECTORY include/${PROJECT_NAME}/
@@ -38,19 +40,21 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}-test test/test_pcl_conversions.cpp)
   ament_target_dependencies(${PROJECT_NAME}-test
+    "pcl_msgs"
     "rclcpp"
     "sensor_msgs"
     "std_msgs"
-    "pcl_msgs"
   )
   target_link_libraries(${PROJECT_NAME}-test ${Boost_LIBRARIES})
 endif()
 
 ament_export_include_directories(
   include
-  ${rclcpp_INCLUDE_DIRS}
   ${Eigen_INCLUDE_DIRS}
+  ${message_filters_INCLUDE_DIRS}
   ${PCL_COMMON_INCLUDE_DIRS}
+  ${pcl_msgs_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
 )
 
 ament_export_dependencies()

--- a/pcl_conversions/include/pcl_conversions/pcl_conversions.h
+++ b/pcl_conversions/include/pcl_conversions/pcl_conversions.h
@@ -121,6 +121,11 @@ namespace pcl_conversions {
   void toPCL(const std_msgs::msg::Header &header, pcl::PCLHeader &pcl_header)
   {
     toPCL(header.stamp, pcl_header.stamp);
+    // TODO(clalancette): Seq doesn't exist in the ROS2 header
+    // anymore.  wjwwood suggests that we might be able to get this
+    // information from the middleware in the future, but for now we
+    // just set it to 0.
+    pcl_header.seq = 0;
     pcl_header.frame_id = header.frame_id;
   }
 
@@ -534,7 +539,7 @@ namespace pcl {
     }
   }
 
-  /** Provide to/fromROSMsg for sensor_msgs::PointCloud2 <=> pcl::PointCloud<T> **/
+  /** Provide to/fromROSMsg for sensor_msgs::msg::PointCloud2 <=> pcl::PointCloud<T> **/
 
   template<typename T>
   void toROSMsg(const pcl::PointCloud<T> &pcl_cloud, sensor_msgs::msg::PointCloud2 &cloud)
@@ -734,9 +739,177 @@ namespace message_filters
   //https://github.com/ros2/message_filters/commit/46e1229a1d8c0ecca68e01b9cf0d8c13f9f6f87a#diff-651c2688431bf33a7ed4f0c68f9d86d2
   namespace message_traits
   {
+//     template<>
+//     struct MD5Sum<pcl::PCLPointCloud2>
+//     {
+//       static const char* value() { return MD5Sum<sensor_msgs::msg::PointCloud2>::value(); }
+//       static const char* value(const pcl::PCLPointCloud2&) { return value(); }
+
+//       static const uint64_t static_value1 = MD5Sum<sensor_msgs::msg::PointCloud2>::static_value1;
+//       static const uint64_t static_value2 = MD5Sum<sensor_msgs::msg::PointCloud2>::static_value2;
+
+//       // If the definition of sensor_msgs/PointCloud2 changes, we'll get a compile error here.
+//       static_assert(static_value1 == 0x1158d486dd51d683ULL);
+//       static_assert(static_value2 == 0xce2f1be655c3c181ULL);
+//     };
+
+//     template<>
+//     struct DataType<pcl::PCLPointCloud2>
+//     {
+//       static const char* value() { return DataType<sensor_msgs::msg::PointCloud2>::value(); }
+//       static const char* value(const pcl::PCLPointCloud2&) { return value(); }
+//     };
+
+//     template<>
+//     struct Definition<pcl::PCLPointCloud2>
+//     {
+//       static const char* value() { return Definition<sensor_msgs::msg::PointCloud2>::value(); }
+//       static const char* value(const pcl::PCLPointCloud2&) { return value(); }
+//     };
+
     template<> struct HasHeader<pcl::PCLPointCloud2> : std::true_type {};
   } // namespace message_filters::message_traits
   //https://answers.ros.org/question/303992/how-to-get-the-serialized-message-sizelength-in-ros2/
+
+//   namespace serialization
+//   {
+//     /*
+//      * Provide a custom serialization for pcl::PCLPointCloud2
+//      */
+//     template<>
+//     struct Serializer<pcl::PCLPointCloud2>
+//     {
+//       template<typename Stream>
+//       inline static void write(Stream& stream, const pcl::PCLPointCloud2& m)
+//       {
+//         std_msgs::msg::Header header;
+//         pcl_conversions::fromPCL(m.header, header);
+//         stream.next(header);
+//         stream.next(m.height);
+//         stream.next(m.width);
+//         std::vector<sensor_msgs::msg::PointField> pfs;
+//         pcl_conversions::fromPCL(m.fields, pfs);
+//         stream.next(pfs);
+//         stream.next(m.is_bigendian);
+//         stream.next(m.point_step);
+//         stream.next(m.row_step);
+//         stream.next(m.data);
+//         stream.next(m.is_dense);
+//       }
+
+//       template<typename Stream>
+//       inline static void read(Stream& stream, pcl::PCLPointCloud2& m)
+//       {
+//         std_msgs::msg::Header header;
+//         stream.next(header);
+//         pcl_conversions::toPCL(header, m.header);
+//         stream.next(m.height);
+//         stream.next(m.width);
+//         std::vector<sensor_msgs::msg::PointField> pfs;
+//         stream.next(pfs);
+//         pcl_conversions::toPCL(pfs, m.fields);
+//         stream.next(m.is_bigendian);
+//         stream.next(m.point_step);
+//         stream.next(m.row_step);
+//         stream.next(m.data);
+//         stream.next(m.is_dense);
+//       }
+
+//       inline static uint32_t serializedLength(const pcl::PCLPointCloud2& m)
+//       {
+//         uint32_t length = 0;
+
+//         std_msgs::msg::Header header;
+//         pcl_conversions::fromPCL(m.header, header);
+//         length += serializationLength(header);
+//         length += 4; // height
+//         length += 4; // width
+//         std::vector<sensor_msgs::msg::PointField> pfs;
+//         pcl_conversions::fromPCL(m.fields, pfs);
+//         length += serializationLength(pfs); // fields
+//         length += 1; // is_bigendian
+//         length += 4; // point_step
+//         length += 4; // row_step
+//         length += 4; // data's size
+//         length += m.data.size() * sizeof(pcl::uint8_t);
+//         length += 1; // is_dense
+
+//         return length;
+//       }
+//     };
+
+//     /*
+//      * Provide a custom serialization for pcl::PCLPointField
+//      */
+//     template<>
+//     struct Serializer<pcl::PCLPointField>
+//     {
+//       template<typename Stream>
+//       inline static void write(Stream& stream, const pcl::PCLPointField& m)
+//       {
+//         stream.next(m.name);
+//         stream.next(m.offset);
+//         stream.next(m.datatype);
+//         stream.next(m.count);
+//       }
+
+//       template<typename Stream>
+//       inline static void read(Stream& stream, pcl::PCLPointField& m)
+//       {
+//         stream.next(m.name);
+//         stream.next(m.offset);
+//         stream.next(m.datatype);
+//         stream.next(m.count);
+//       }
+
+//       inline static uint32_t serializedLength(const pcl::PCLPointField& m)
+//       {
+//         uint32_t length = 0;
+
+//         length += serializationLength(m.name);
+//         length += serializationLength(m.offset);
+//         length += serializationLength(m.datatype);
+//         length += serializationLength(m.count);
+
+//         return length;
+//       }
+//     };
+
+//     /*
+//      * Provide a custom serialization for pcl::PCLHeader
+//      */
+//     template<>
+//     struct Serializer<pcl::PCLHeader>
+//     {
+//       template<typename Stream>
+//       inline static void write(Stream& stream, const pcl::PCLHeader& m)
+//       {
+//         std_msgs::msg::Header header;
+//         pcl_conversions::fromPCL(m, header);
+//         stream.next(header);
+//       }
+
+//       template<typename Stream>
+//       inline static void read(Stream& stream, pcl::PCLHeader& m)
+//       {
+//         std_msgs::msg::Header header;
+//         stream.next(header);
+//         pcl_conversions::toPCL(header, m);
+//       }
+
+//       inline static uint32_t serializedLength(const pcl::PCLHeader& m)
+//       {
+//         uint32_t length = 0;
+
+//         std_msgs::msg::Header header;
+//         pcl_conversions::fromPCL(m, header);
+//         length += serializationLength(header);
+
+//         return length;
+//       }
+//     };
+//   } // namespace ros::serialization
+
 } // namespace message_filters
 
 

--- a/pcl_conversions/package.xml
+++ b/pcl_conversions/package.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>pcl_conversions</name>
-  <version>2.0.0</version>
+  <version>1.6.2</version>
   <description>Provides conversions from PCL data types and ROS message types</description>
 
   <author email="william@osrfoundation.org">William Woodall</author>
+  <author email="paul@bovbel.com">Paul Bovbel</author>
+  <author email="bill@neautomation.com">Bill Morris</author>
   <author email="ankl@kth.se">Andreas Klintberg</author>
 
   <maintainer email="paul@bovbel.com">Paul Bovbel</maintainer>

--- a/pcl_conversions/package.xml
+++ b/pcl_conversions/package.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="3">
+<package format="2">
   <name>pcl_conversions</name>
-  <version>1.6.2</version>
+  <version>2.0.0</version>
   <description>Provides conversions from PCL data types and ROS message types</description>
 
   <author email="william@osrfoundation.org">William Woodall</author>
@@ -19,20 +18,26 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>eigen</build_depend>
+  <build_depend>libpcl-all-dev</build_depend>
+  <build_depend>message_filters</build_depend>
+  <build_depend>pcl_msgs</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+
   <build_export_depend>eigen</build_export_depend>
   <build_export_depend>libpcl-all-dev</build_export_depend>
+  <build_export_depend>message_filters</build_export_depend>
   <build_export_depend>pcl_msgs</build_export_depend>
   <build_export_depend>rclcpp</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
 
-  <test_depend>eigen</test_depend>
-  <test_depend>libpcl-all-dev</test_depend>
-  <test_depend>pcl_msgs</test_depend>
-  <test_depend>roscpp</test_depend>
-  <test_depend>sensor_msgs</test_depend>
-  <test_depend>std_msgs</test_depend>
-  
+  <exec_depend>libpcl-all-dev</exec_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/pcl_conversions/test/test_pcl_conversions.cpp
+++ b/pcl_conversions/test/test_pcl_conversions.cpp
@@ -41,21 +41,21 @@ protected:
   }
 
   pcl::PCLImage pcl_image;
-  sensor_msgs::Image image;
+  sensor_msgs::msg::Image image;
 
   pcl::PCLPointCloud2 pcl_pc2;
-  sensor_msgs::PointCloud2 pc2;
+  sensor_msgs::msg::PointCloud2 pc2;
 };
 
 template<class T>
 void test_image(T &image) {
   EXPECT_EQ(std::string("pcl"), image.header.frame_id);
-  EXPECT_EQ(1, image.height);
-  EXPECT_EQ(2, image.width);
-  EXPECT_EQ(1, image.step);
+  EXPECT_EQ(1U, image.height);
+  EXPECT_EQ(2U, image.width);
+  EXPECT_EQ(1U, image.step);
   EXPECT_TRUE(image.is_bigendian);
   EXPECT_EQ(std::string("bgr8"), image.encoding);
-  EXPECT_EQ(2, image.data.size());
+  EXPECT_EQ(2U, image.data.size());
   EXPECT_EQ(0x42, image.data[0]);
   EXPECT_EQ(0x43, image.data[1]);
 }
@@ -71,21 +71,21 @@ TEST_F(PCLConversionTests, imageConversion) {
 template<class T>
 void test_pc(T &pc) {
   EXPECT_EQ(std::string("pcl"), pc.header.frame_id);
-  EXPECT_EQ(1, pc.height);
-  EXPECT_EQ(2, pc.width);
-  EXPECT_EQ(1, pc.point_step);
-  EXPECT_EQ(1, pc.row_step);
+  EXPECT_EQ(1U, pc.height);
+  EXPECT_EQ(2U, pc.width);
+  EXPECT_EQ(1U, pc.point_step);
+  EXPECT_EQ(1U, pc.row_step);
   EXPECT_TRUE(pc.is_bigendian);
   EXPECT_TRUE(pc.is_dense);
   EXPECT_EQ("XYZ", pc.fields[0].name);
   EXPECT_EQ(pcl::PCLPointField::INT8, pc.fields[0].datatype);
-  EXPECT_EQ(3, pc.fields[0].count);
-  EXPECT_EQ(0, pc.fields[0].offset);
+  EXPECT_EQ(3U, pc.fields[0].count);
+  EXPECT_EQ(0U, pc.fields[0].offset);
   EXPECT_EQ("RGB", pc.fields[1].name);
   EXPECT_EQ(pcl::PCLPointField::INT8, pc.fields[1].datatype);
-  EXPECT_EQ(3, pc.fields[1].count);
-  EXPECT_EQ(8 * 3, pc.fields[1].offset);
-  EXPECT_EQ(2, pc.data.size());
+  EXPECT_EQ(3U, pc.fields[1].count);
+  EXPECT_EQ(8U * 3U, pc.fields[1].offset);
+  EXPECT_EQ(2U, pc.data.size());
   EXPECT_EQ(0x42, pc.data[0]);
   EXPECT_EQ(0x43, pc.data[1]);
 }
@@ -103,10 +103,10 @@ TEST_F(PCLConversionTests, pointcloud2Conversion) {
 
 struct StampTestData
 {
-  const ros::Time stamp_;
-  ros::Time stamp2_;
+  const rclcpp::Time stamp_;
+  rclcpp::Time stamp2_;
 
-  explicit StampTestData(const ros::Time &stamp)
+  explicit StampTestData(const rclcpp::Time &stamp)
     : stamp_(stamp)
   {
     pcl::uint64_t pcl_stamp;
@@ -118,27 +118,27 @@ struct StampTestData
 TEST(PCLConversionStamp, Stamps)
 {
   {
-    const StampTestData d(ros::Time(1.000001));
+    const StampTestData d(rclcpp::Time(1, 1000));
     EXPECT_TRUE(d.stamp_==d.stamp2_);
   }
 
   {
-    const StampTestData d(ros::Time(1.999999));
+    const StampTestData d(rclcpp::Time(1, 999999000));
     EXPECT_TRUE(d.stamp_==d.stamp2_);
   }
 
   {
-    const StampTestData d(ros::Time(1.999));
+    const StampTestData d(rclcpp::Time(1, 999000000));
     EXPECT_TRUE(d.stamp_==d.stamp2_);
   }
 
   {
-    const StampTestData d(ros::Time(1423680574, 746000000));
+    const StampTestData d(rclcpp::Time(1423680574, 746000000));
     EXPECT_TRUE(d.stamp_==d.stamp2_);
   }
 
   {
-    const StampTestData d(ros::Time(1423680629, 901000000));
+    const StampTestData d(rclcpp::Time(1423680629, 901000000));
     EXPECT_TRUE(d.stamp_==d.stamp2_);
   }
 }


### PR DESCRIPTION
I'm helping to hopefully get `perception_pcl` stack released in ROS 2.
The `pcl_conversions` portion of it had been ported to ROS 2 about two years ago, and has been the officially released Debian in ROS 2. https://github.com/ros2/pcl_conversions
https://github.com/ros/rosdistro/blob/master/dashing/distribution.yaml#L1296

Since there are more recent efforts to port the `perception_pcl` to ROS 2, we figured the officially released `pcl_conversions` should be merged to this, and then we can deprecate `pcl_conversions`, and in the future release `perception_pcl`.

This PR merges ros2/pcl_conversions with this repo. The test file is ported to ROS 2 and passes.
For reviewing, I'm not sure if GitHub can show a diff between this repo and ros2/pcl_conversions. That might have to be manually done by the reviewer.